### PR TITLE
test: assert error details for supabase test

### DIFF
--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -1,5 +1,5 @@
 import { supabase } from '../lib/supabaseClient'
-import { createClient } from 'supabase'
+import { createClient } from '@supabase/supabase-js'
 
 describe('Supabase Connection', () => {
   test('should successfully connect to Supabase', async () => {
@@ -19,8 +19,9 @@ describe('Supabase Connection', () => {
     const { data, error } = await invalidSupabase
       .from('companies')
       .select('*')
-    
+
     expect(error).toBeTruthy()
+    expect(error?.message || error?.status).toBeTruthy()
     expect(data).toBeNull()
   })
-}) 
+})


### PR DESCRIPTION
## Summary
- use `@supabase/supabase-js` for `createClient` in basic test
- assert error contains message or status in failed connection test

## Testing
- `npm test` *(fails: Jest encountered unexpected token in dist/__tests__/utils/test-utils.js)*

------
https://chatgpt.com/codex/tasks/task_b_688fe28b4bf4833388e07245253b73b2