### PR TITLE
feat: parse userId in reviews hook

### DIFF
--- a/src/hooks/useReviews.test.ts
+++ b/src/hooks/useReviews.test.ts
@@ -1,0 +1,18 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useReviews } from './useReviews';
+import { getReviews } from '@/lib/database';
+
+vi.mock('@/lib/database', () => ({
+  getReviews: vi.fn().mockResolvedValue({ data: [], error: null }),
+}));
+
+describe('useReviews', () => {
+  it('converts string userId to number', async () => {
+    renderHook(() => useReviews({ companyId: '1', userId: '2' }));
+
+    await waitFor(() => {
+      expect(getReviews).toHaveBeenCalledWith({ companyId: 1, userId: 2 });
+    });
+  });
+});

--- a/src/hooks/useReviews.ts
+++ b/src/hooks/useReviews.ts
@@ -28,8 +28,11 @@ export const useReviews = (options: GetReviewsOptions = {}): UseReviewsResult =>
         // Convert string IDs to proper types if provided
         const parsedOptions = {
           ...options,
-          companyId: options.companyId ? 
-            (typeof options.companyId === 'string' ? parseInt(options.companyId, 10) : options.companyId) : 
+          companyId: options.companyId ?
+            (typeof options.companyId === 'string' ? parseInt(options.companyId, 10) : options.companyId) :
+            undefined,
+          userId: options.userId ?
+            (typeof options.userId === 'string' ? parseInt(options.userId, 10) : options.userId) :
             undefined,
         };
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -144,7 +144,7 @@ export interface GetReviewsOptions {
   page?: number;
   limit?: number;
   companyId?: number | string;
-  userId?: string;
+  userId?: number | string;
   withCompany?: boolean;
   withLikes?: boolean;
 }


### PR DESCRIPTION
## Summary
- convert `userId` option from string to number in `useReviews`
- allow numeric `userId` in `GetReviewsOptions`
- test that `useReviews` parses string IDs correctly

## Testing
- `npm install --no-save vitest @testing-library/react @testing-library/jest-dom` *(fails: 403 Forbidden)*
- `npx vitest run src/hooks/useReviews.test.ts` *(fails: 403 Forbidden)*
- `npm test` *(fails: missing modules and syntax errors)*

------
https://chatgpt.com/codex/tasks/task_b_688fe28360d48333be5ae6cb7adab3ba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of company and user IDs to ensure both are correctly parsed as numbers when needed.

* **Tests**
  * Added unit tests to verify correct parsing of company and user IDs in review-related functionality.

* **Refactor**
  * Updated type definitions to allow user IDs to be either numbers or strings for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->