### PR TITLE
Fix auth links and analytics rating field

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function LoginPage() {
+  redirect('/auth/login');
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function SignupPage() {
+  redirect('/auth/login?signup=true');
+}

--- a/src/components/analytics/IndustryInsights.tsx
+++ b/src/components/analytics/IndustryInsights.tsx
@@ -98,7 +98,7 @@ export function IndustryInsights({
   }
 
   const topIndustries = industryStats.slice(0, limit);
-  const maxRating = Math.max(...topIndustries.map(stat => stat.average_rating));
+  const maxRating = Math.max(...topIndustries.map(stat => stat.average_rating ?? 0));
   const totalCompanies = topIndustries.reduce((sum, stat) => sum + stat.company_count, 0);
   const totalReviews = topIndustries.reduce((sum, stat) => sum + stat.review_count, 0);
 
@@ -153,19 +153,19 @@ export function IndustryInsights({
                 </div>
                 <div className="flex items-center gap-2">
                   <span className={`font-bold ${getRatingColor(stat.average_rating)}`}>
-                    {stat.average_rating.toFixed(1)}
+                    {Number(stat.average_rating ?? 0).toFixed(2)}
                   </span>
                   <div className={`px-2 py-1 rounded text-xs ${getRatingBgColor(stat.average_rating)}`}>
-                    {stat.average_rating >= 4 ? 'Excellent' : 
-                     stat.average_rating >= 3.5 ? 'Good' : 
+                    {stat.average_rating >= 4 ? 'Excellent' :
+                     stat.average_rating >= 3.5 ? 'Good' :
                      stat.average_rating >= 2.5 ? 'Fair' : 'Poor'}
                   </div>
                 </div>
               </div>
-              
+
               <div className="ml-9">
-                <Progress 
-                  value={(stat.average_rating / 5) * 100} 
+                <Progress
+                  value={((stat.average_rating ?? 0) / 5) * 100}
                   className="h-2"
                 />
                 <div className="flex justify-between text-xs text-gray-500 mt-1">
@@ -186,11 +186,11 @@ export function IndustryInsights({
             <h4 className="font-medium text-blue-800 mb-2">Key Insights</h4>
             <ul className="text-sm text-blue-700 space-y-1">
               <li>
-                • <strong>{topIndustries[0].industry}</strong> leads with {topIndustries[0].average_rating.toFixed(1)}/5 rating
+                • <strong>{topIndustries[0].industry}</strong> leads with {Number(topIndustries[0].average_rating ?? 0).toFixed(2)}/5 rating
               </li>
               {topIndustries.length > 1 && (
                 <li>
-                  • Rating gap of {(topIndustries[0].average_rating - topIndustries[topIndustries.length - 1].average_rating).toFixed(1)} points between top and bottom industries
+                  • Rating gap of {Number((topIndustries[0].average_rating ?? 0) - (topIndustries[topIndustries.length - 1].average_rating ?? 0)).toFixed(2)} points between top and bottom industries
                 </li>
               )}
               <li>

--- a/src/components/analytics/IndustryInsights.tsx
+++ b/src/components/analytics/IndustryInsights.tsx
@@ -98,7 +98,7 @@ export function IndustryInsights({
   }
 
   const topIndustries = industryStats.slice(0, limit);
-  const maxRating = Math.max(...topIndustries.map(stat => stat.average_rating ?? 0));
+  const maxRating = Math.max(...topIndustries.map(stat => stat.average_rating ?? stat.avg_rating ?? 0));
   const totalCompanies = topIndustries.reduce((sum, stat) => sum + stat.company_count, 0);
   const totalReviews = topIndustries.reduce((sum, stat) => sum + stat.review_count, 0);
 
@@ -152,20 +152,20 @@ export function IndustryInsights({
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className={`font-bold ${getRatingColor(stat.average_rating)}`}>
-                    {Number(stat.average_rating ?? 0).toFixed(2)}
+                  <span className={`font-bold ${getRatingColor(stat.average_rating ?? stat.avg_rating ?? 0)}`}>
+                    {Number(stat.average_rating ?? stat.avg_rating ?? 0).toFixed(2)}
                   </span>
-                  <div className={`px-2 py-1 rounded text-xs ${getRatingBgColor(stat.average_rating)}`}>
-                    {stat.average_rating >= 4 ? 'Excellent' :
-                     stat.average_rating >= 3.5 ? 'Good' :
-                     stat.average_rating >= 2.5 ? 'Fair' : 'Poor'}
+                  <div className={`px-2 py-1 rounded text-xs ${getRatingBgColor(stat.average_rating ?? stat.avg_rating ?? 0)}`}>
+                    {(stat.average_rating ?? stat.avg_rating ?? 0) >= 4 ? 'Excellent' :
+                     (stat.average_rating ?? stat.avg_rating ?? 0) >= 3.5 ? 'Good' :
+                     (stat.average_rating ?? stat.avg_rating ?? 0) >= 2.5 ? 'Fair' : 'Poor'}
                   </div>
                 </div>
               </div>
 
               <div className="ml-9">
                 <Progress
-                  value={((stat.average_rating ?? 0) / 5) * 100}
+                  value={((stat.average_rating ?? stat.avg_rating ?? 0) / 5) * 100}
                   className="h-2"
                 />
                 <div className="flex justify-between text-xs text-gray-500 mt-1">
@@ -186,15 +186,15 @@ export function IndustryInsights({
             <h4 className="font-medium text-blue-800 mb-2">Key Insights</h4>
             <ul className="text-sm text-blue-700 space-y-1">
               <li>
-                • <strong>{topIndustries[0].industry}</strong> leads with {Number(topIndustries[0].average_rating ?? 0).toFixed(2)}/5 rating
+                • <strong>{topIndustries[0].industry}</strong> leads with {Number(topIndustries[0].average_rating ?? topIndustries[0].avg_rating ?? 0).toFixed(2)}/5 rating
               </li>
               {topIndustries.length > 1 && (
                 <li>
-                  • Rating gap of {Number((topIndustries[0].average_rating ?? 0) - (topIndustries[topIndustries.length - 1].average_rating ?? 0)).toFixed(2)} points between top and bottom industries
+                  • Rating gap of {Number((topIndustries[0].average_rating ?? topIndustries[0].avg_rating ?? 0) - (topIndustries[topIndustries.length - 1].average_rating ?? topIndustries[topIndustries.length - 1].avg_rating ?? 0)).toFixed(2)} points between top and bottom industries
                 </li>
               )}
               <li>
-                • {topIndustries.filter(stat => stat.average_rating >= 4).length} industries rated "Excellent" (4.0+)
+                • {topIndustries.filter(stat => (stat.average_rating ?? stat.avg_rating ?? 0) >= 4).length} industries rated "Excellent" (4.0+)
               </li>
             </ul>
           </div>

--- a/src/components/analytics/LocationInsights.tsx
+++ b/src/components/analytics/LocationInsights.tsx
@@ -110,7 +110,11 @@ export function LocationInsights({
   const topLocations = locationStats.slice(0, limit);
   const totalCompanies = topLocations.reduce((sum, stat) => sum + stat.company_count, 0);
   const totalReviews = topLocations.reduce((sum, stat) => sum + stat.review_count, 0);
-  const averageRating = topLocations.reduce((sum, stat) => sum + (stat.average_rating ?? 0), 0) / topLocations.length;
+  const averageRating =
+    topLocations.reduce(
+      (sum, stat) => sum + (stat.average_rating ?? stat.avg_rating ?? 0),
+      0
+    ) / topLocations.length;
 
   return (
     <Card className={className}>
@@ -162,14 +166,14 @@ export function LocationInsights({
                       <p className="text-sm text-gray-500">{getLocationSize(stat.company_count)}</p>
                     </div>
                   </div>
-                  <div className={`px-2 py-1 rounded-full text-sm font-medium ${getRatingBadgeColor(stat.average_rating)}`}>
-                    {Number(stat.average_rating ?? 0).toFixed(2)}
+                  <div className={`px-2 py-1 rounded-full text-sm font-medium ${getRatingBadgeColor(stat.average_rating ?? stat.avg_rating ?? 0)}`}>
+                    {Number(stat.average_rating ?? stat.avg_rating ?? 0).toFixed(2)}
                   </div>
                 </div>
 
                 <div className="mb-3">
                   <Progress
-                    value={((stat.average_rating ?? 0) / 5) * 100}
+                    value={((stat.average_rating ?? stat.avg_rating ?? 0) / 5) * 100}
                     className="h-2"
                   />
                 </div>
@@ -188,9 +192,9 @@ export function LocationInsights({
                   <div className="flex items-center gap-1 text-gray-600">
                     <Star className="h-3 w-3" />
                     <span className="text-xs">
-                      {stat.average_rating >= 4 ? 'Excellent' : 
-                       stat.average_rating >= 3.5 ? 'Good' : 
-                       stat.average_rating >= 2.5 ? 'Fair' : 'Poor'}
+                      {(stat.average_rating ?? stat.avg_rating ?? 0) >= 4 ? 'Excellent' :
+                       (stat.average_rating ?? stat.avg_rating ?? 0) >= 3.5 ? 'Good' :
+                       (stat.average_rating ?? stat.avg_rating ?? 0) >= 2.5 ? 'Fair' : 'Poor'}
                     </span>
                   </div>
                 </div>
@@ -205,17 +209,17 @@ export function LocationInsights({
             <h4 className="font-medium text-green-800 mb-2">Market Analysis</h4>
             <div className="text-sm text-green-700 space-y-1">
                 <p>
-                  • <strong>{topLocations[0].location}</strong> leads with {Number(topLocations[0].average_rating ?? 0).toFixed(2)}/5 rating
+                  • <strong>{topLocations[0].location}</strong> leads with {Number(topLocations[0].average_rating ?? topLocations[0].avg_rating ?? 0).toFixed(2)}/5 rating
                 </p>
               <p>
                 • {topLocations.filter(stat => stat.company_count >= 50).length} major employment hubs identified
               </p>
               <p>
-                • {topLocations.filter(stat => stat.average_rating >= 4).length} locations rated "Excellent" (4.0+)
+                • {topLocations.filter(stat => (stat.average_rating ?? stat.avg_rating ?? 0) >= 4).length} locations rated "Excellent" (4.0+)
               </p>
               {topLocations.length > 1 && (
                   <p>
-                    • Rating spread: {Number((topLocations[0].average_rating ?? 0) - (topLocations[topLocations.length - 1].average_rating ?? 0)).toFixed(2)} points
+                    • Rating spread: {Number((topLocations[0].average_rating ?? topLocations[0].avg_rating ?? 0) - (topLocations[topLocations.length - 1].average_rating ?? topLocations[topLocations.length - 1].avg_rating ?? 0)).toFixed(2)} points
                   </p>
                 )}
             </div>

--- a/src/components/analytics/LocationInsights.tsx
+++ b/src/components/analytics/LocationInsights.tsx
@@ -110,7 +110,7 @@ export function LocationInsights({
   const topLocations = locationStats.slice(0, limit);
   const totalCompanies = topLocations.reduce((sum, stat) => sum + stat.company_count, 0);
   const totalReviews = topLocations.reduce((sum, stat) => sum + stat.review_count, 0);
-  const averageRating = topLocations.reduce((sum, stat) => sum + stat.average_rating, 0) / topLocations.length;
+  const averageRating = topLocations.reduce((sum, stat) => sum + (stat.average_rating ?? 0), 0) / topLocations.length;
 
   return (
     <Card className={className}>
@@ -140,7 +140,7 @@ export function LocationInsights({
           </div>
           <div className="text-center">
             <div className={`text-xl font-bold ${getRatingColor(averageRating)}`}>
-              {averageRating.toFixed(1)}
+              {Number(averageRating ?? 0).toFixed(2)}
             </div>
             <div className="text-xs text-gray-600">Avg Rating</div>
           </div>
@@ -163,13 +163,13 @@ export function LocationInsights({
                     </div>
                   </div>
                   <div className={`px-2 py-1 rounded-full text-sm font-medium ${getRatingBadgeColor(stat.average_rating)}`}>
-                    {stat.average_rating.toFixed(1)}
+                    {Number(stat.average_rating ?? 0).toFixed(2)}
                   </div>
                 </div>
 
                 <div className="mb-3">
-                  <Progress 
-                    value={(stat.average_rating / 5) * 100} 
+                  <Progress
+                    value={((stat.average_rating ?? 0) / 5) * 100}
                     className="h-2"
                   />
                 </div>
@@ -204,9 +204,9 @@ export function LocationInsights({
           <div className="p-4 bg-green-50 rounded-lg">
             <h4 className="font-medium text-green-800 mb-2">Market Analysis</h4>
             <div className="text-sm text-green-700 space-y-1">
-              <p>
-                • <strong>{topLocations[0].location}</strong> leads with {topLocations[0].average_rating.toFixed(1)}/5 rating
-              </p>
+                <p>
+                  • <strong>{topLocations[0].location}</strong> leads with {Number(topLocations[0].average_rating ?? 0).toFixed(2)}/5 rating
+                </p>
               <p>
                 • {topLocations.filter(stat => stat.company_count >= 50).length} major employment hubs identified
               </p>
@@ -214,10 +214,10 @@ export function LocationInsights({
                 • {topLocations.filter(stat => stat.average_rating >= 4).length} locations rated "Excellent" (4.0+)
               </p>
               {topLocations.length > 1 && (
-                <p>
-                  • Rating spread: {(topLocations[0].average_rating - topLocations[topLocations.length - 1].average_rating).toFixed(1)} points
-                </p>
-              )}
+                  <p>
+                    • Rating spread: {Number((topLocations[0].average_rating ?? 0) - (topLocations[topLocations.length - 1].average_rating ?? 0)).toFixed(2)} points
+                  </p>
+                )}
             </div>
           </div>
         )}

--- a/src/components/ui/enhanced-navbar.tsx
+++ b/src/components/ui/enhanced-navbar.tsx
@@ -327,8 +327,12 @@ const EnhancedNavbar: React.FC<EnhancedNavbarProps> = ({
               </div>
             ) : (
               <div className="flex items-center space-x-2">
-                <EnhancedButton variant="ghost">Sign In</EnhancedButton>
-                <EnhancedButton>Sign Up</EnhancedButton>
+                <EnhancedButton asChild variant="ghost">
+                  <Link href="/auth/login">Sign In</Link>
+                </EnhancedButton>
+                <EnhancedButton asChild>
+                  <Link href="/auth/login?signup=true">Sign Up</Link>
+                </EnhancedButton>
               </div>
             )}
 

--- a/src/lib/auth/withAuth.tsx
+++ b/src/lib/auth/withAuth.tsx
@@ -55,7 +55,7 @@ export function withAuth<P extends object>(
   WrappedComponent: ComponentType<P>,
   options: WithAuthProps = {}
 ) {
-  const { requiredRole, redirectTo = '/login' } = options;
+  const { requiredRole, redirectTo = '/auth/login' } = options;
   
   return function ProtectedRoute(props: P) {
     const router = useRouter();

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -10,6 +10,7 @@ const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey);
 export type IndustryStatistic = {
   industry: string;
   avg_rating: number;
+  average_rating: number;
   company_count: number;
   review_count: number;
 };
@@ -17,6 +18,7 @@ export type IndustryStatistic = {
 export type LocationStatistic = {
   location: string;
   avg_rating: number;
+  average_rating: number;
   company_count: number;
   review_count: number;
 };
@@ -69,14 +71,18 @@ export async function getIndustryStatistics(): Promise<IndustryStatistic[]> {
     });
 
     // Convert map to array of statistics
-    const statistics: IndustryStatistic[] = Array.from(industryMap.entries()).map(([industry, stats]) => ({
-      industry,
-      avg_rating: stats.ratings.length > 0 
-        ? stats.ratings.reduce((sum, rating) => sum + rating, 0) / stats.ratings.length 
-        : 0,
-      company_count: stats.companies.size,
-      review_count: stats.reviews
-    }));
+    const statistics: IndustryStatistic[] = Array.from(industryMap.entries()).map(([industry, stats]) => {
+      const avg_rating = stats.ratings.length > 0
+        ? stats.ratings.reduce((sum, rating) => sum + rating, 0) / stats.ratings.length
+        : 0;
+      return {
+        industry,
+        avg_rating,
+        average_rating: avg_rating,
+        company_count: stats.companies.size,
+        review_count: stats.reviews
+      };
+    });
 
     // Sort by average rating descending
     return statistics.sort((a, b) => b.avg_rating - a.avg_rating);
@@ -134,14 +140,18 @@ export async function getLocationStatistics(): Promise<LocationStatistic[]> {
     });
 
     // Convert map to array of statistics
-    const statistics: LocationStatistic[] = Array.from(locationMap.entries()).map(([location, stats]) => ({
-      location,
-      avg_rating: stats.ratings.length > 0 
-        ? stats.ratings.reduce((sum, rating) => sum + rating, 0) / stats.ratings.length 
-        : 0,
-      company_count: stats.companies.size,
-      review_count: stats.reviews
-    }));
+    const statistics: LocationStatistic[] = Array.from(locationMap.entries()).map(([location, stats]) => {
+      const avg_rating = stats.ratings.length > 0
+        ? stats.ratings.reduce((sum, rating) => sum + rating, 0) / stats.ratings.length
+        : 0;
+      return {
+        location,
+        avg_rating,
+        average_rating: avg_rating,
+        company_count: stats.companies.size,
+        review_count: stats.reviews
+      };
+    });
 
     // Sort by average rating descending
     return statistics.sort((a, b) => b.avg_rating - a.avg_rating);
@@ -207,14 +217,18 @@ export async function getAllIndustryStatistics(): Promise<IndustryStatistic[]> {
     });
 
     // Convert map to array of statistics
-    const statistics: IndustryStatistic[] = Array.from(industryMap.entries()).map(([industry, stats]) => ({
-      industry,
-      avg_rating: stats.ratings.length > 0 
-        ? stats.ratings.reduce((sum, rating) => sum + rating, 0) / stats.ratings.length 
-        : 0,
-      company_count: stats.companies.size,
-      review_count: stats.reviews
-    }));
+    const statistics: IndustryStatistic[] = Array.from(industryMap.entries()).map(([industry, stats]) => {
+      const avg_rating = stats.ratings.length > 0
+        ? stats.ratings.reduce((sum, rating) => sum + rating, 0) / stats.ratings.length
+        : 0;
+      return {
+        industry,
+        avg_rating,
+        average_rating: avg_rating,
+        company_count: stats.companies.size,
+        review_count: stats.reviews
+      };
+    });
 
     // Sort by average rating descending
     return statistics.sort((a, b) => b.avg_rating - a.avg_rating);
@@ -280,14 +294,18 @@ export async function getAllLocationStatistics(): Promise<LocationStatistic[]> {
     });
 
     // Convert map to array of statistics
-    const statistics: LocationStatistic[] = Array.from(locationMap.entries()).map(([location, stats]) => ({
-      location,
-      avg_rating: stats.ratings.length > 0 
-        ? stats.ratings.reduce((sum, rating) => sum + rating, 0) / stats.ratings.length 
-        : 0,
-      company_count: stats.companies.size,
-      review_count: stats.reviews
-    }));
+    const statistics: LocationStatistic[] = Array.from(locationMap.entries()).map(([location, stats]) => {
+      const avg_rating = stats.ratings.length > 0
+        ? stats.ratings.reduce((sum, rating) => sum + rating, 0) / stats.ratings.length
+        : 0;
+      return {
+        location,
+        avg_rating,
+        average_rating: avg_rating,
+        company_count: stats.companies.size,
+        review_count: stats.reviews
+      };
+    });
 
     // Sort by average rating descending
     return statistics.sort((a, b) => b.avg_rating - a.avg_rating);


### PR DESCRIPTION
## Summary
- redirect sign-in and sign-up links to `/auth/login`
- add `/login` and `/signup` route aliases
- normalize analytics stats to expose `average_rating` and guard `.toFixed`

## Testing
- `npm test` *(fails: Failed to resolve import "node-mocks-http" and numerous component/integration test assertions)*

------
https://chatgpt.com/codex/tasks/task_b_68a67dd4241c8333aa3121e2938d13a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - /login now redirects to /auth/login; /signup redirects to /auth/login?signup=true for unified authentication.
  - Navbar Sign In/Sign Up use faster client-side navigation.
- Bug Fixes
  - Analytics views now handle missing ratings safely, preventing errors and incorrect progress displays.
- Style
  - Industry and Location ratings consistently show two-decimal precision.
- Chores
  - Default unauthenticated redirect updated to /auth/login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->