### PR TITLE
Handle missing data gracefully and gate unauthenticated forms

### DIFF
--- a/src/components/CompanyForm.tsx
+++ b/src/components/CompanyForm.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 import { companySchema, type CompanyFormData } from '@/lib/schemas';
 import { createClient } from '@/lib/supabaseClient';
 import { useAuth } from '@/contexts/AuthContext';
+import Link from 'next/link';
 import { ErrorDisplay } from "@/components/ErrorDisplay";
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { LocationAutocomplete } from '@/components/LocationAutocomplete';
@@ -28,6 +29,18 @@ export function CompanyForm({ initialData, onSuccess }: CompanyFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [locationError, setLocationError] = useState<string | null>(null);
+
+  // Auth gate: show CTA instead of a dead form when not signed in
+  if (!user) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+        <p className="mb-2 font-medium">Please sign in to add a company.</p>
+        <Link href="/auth/login?signup=true" className="underline underline-offset-2">
+          Sign in / Create account
+        </Link>
+      </div>
+    );
+  }
 
   const {
     register,

--- a/src/components/ReviewForm.tsx
+++ b/src/components/ReviewForm.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { supabase } from '@/lib/supabaseClient';
 import { reviewSchema, type ReviewFormData, employmentStatusEnum } from '@/lib/schemas';
 import { useAuth } from '@/contexts/AuthContext';
+import Link from 'next/link';
 import type { CompanyId, JoinedCompany, ReviewInsert, Review } from '@/types/database';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -67,6 +68,18 @@ export const ReviewForm = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedCompany, setSelectedCompany] = useState<JoinedCompany | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  // Auth gate: show CTA instead of form when not signed in
+  if (!user) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm">
+        <p className="mb-2 font-medium">Please sign in to write a review.</p>
+        <Link href="/auth/login?signup=true" className="underline underline-offset-2">
+          Sign in / Create account
+        </Link>
+      </div>
+    );
+  }
 
   const {
     register,

--- a/src/components/SetupRequired.tsx
+++ b/src/components/SetupRequired.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AlertTriangle } from 'lucide-react';
+
+export default function SetupRequired({
+  title = 'Setup Required',
+  steps = [
+    'Ensure NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are set.',
+    'Run: supabase link --project-ref <your-project-ref>',
+    'Run: supabase db push (or supabase migration up) to create required functions/tables.'
+  ],
+  note
+}: {
+  title?: string;
+  steps?: string[];
+  note?: string;
+}) {
+  return (
+    <Card className="border-amber-200 bg-amber-50/60 dark:bg-amber-950/20">
+      <CardHeader className="flex flex-row items-center gap-2">
+        <AlertTriangle className="h-5 w-5 text-amber-600" />
+        <CardTitle className="text-amber-800 dark:text-amber-200">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <ol className="list-decimal pl-5 space-y-1">
+          {steps.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ol>
+        {note && <p className="text-xs opacity-80">{note}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/lib/companySectionsApi.ts
+++ b/src/lib/companySectionsApi.ts
@@ -36,7 +36,12 @@ export async function getFinancialDistressCompanies(
 
     if (error) {
       console.error('Error fetching distress companies:', error);
-      throw error;
+      return {
+        companies: [],
+        total_count: 0,
+        average_distress_score: 0,
+        most_common_indicator: 'layoffs' as any
+      };
     }
 
     if (!companiesData || companiesData.length === 0) {
@@ -168,7 +173,13 @@ export async function getRisingStartupCompanies(
 
     if (error) {
       console.error('Error fetching rising startups:', error);
-      throw error;
+      return {
+        companies: [],
+        total_count: 0,
+        average_growth_score: 0,
+        total_funding: 0,
+        most_common_indicator: 'hiring_spree' as any
+      };
     }
 
     if (!companiesData || companiesData.length === 0) {
@@ -375,7 +386,15 @@ export async function getDistressStatistics(): Promise<DistressStatistics> {
     const { data: companies, error } = await supabase
       .rpc('get_financial_distress_companies', { limit_param: 1000 });
 
-    if (error) throw error;
+    if (error) {
+      return {
+        total_companies: 0,
+        average_score: 0,
+        by_industry: [],
+        by_indicator_type: [],
+        trend_data: []
+      };
+    }
 
     const totalCompanies = companies?.length || 0;
     const averageScore = totalCompanies > 0 
@@ -421,7 +440,16 @@ export async function getGrowthStatistics(): Promise<GrowthStatistics> {
     const { data: companies, error } = await supabase
       .rpc('get_rising_startup_companies', { limit_param: 1000 });
 
-    if (error) throw error;
+    if (error) {
+      return {
+        total_companies: 0,
+        average_score: 0,
+        total_funding: 0,
+        by_industry: [],
+        by_indicator_type: [],
+        trend_data: []
+      };
+    }
 
     const totalCompanies = companies?.length || 0;
     const averageScore = totalCompanies > 0 


### PR DESCRIPTION
## Summary
- return empty placeholder data if insights RPCs are missing
- show a setup checklist on the web scraping dashboard when required tables are absent
- prompt unauthenticated users to sign in before adding companies or reviews

## Testing
- `npm test` *(fails: Failed to resolve import "node-mocks-http"; multiple test assertions failing)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a68996d1a883338a58cad8f2f1bbd6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added sign-in prompts to Company and Review forms for unauthenticated users, with a direct link to log in or sign up.
  - Introduced a “Setup Required” alert in the Web Scraping dashboard that guides users through necessary setup steps when configuration is incomplete.

- Bug Fixes
  - Improved resilience across company data sections by returning safe defaults on data errors, reducing crashes and showing empty states instead.
  - Web Scraping dashboard now handles setup-related failures gracefully, displaying guidance instead of generic errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->