### PR TITLE
feat(db+ingest): insights RPCs, scraping tables, and RSS ingestion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.4",
+        "dotenv": "^16.4.5",
         "framer-motion": "^12.0.6",
         "lucide-react": "^0.474.0",
         "next": "^14.1.0",
@@ -44,6 +45,7 @@
         "react-hook-form": "^7.54.2",
         "react-icons": "^5.4.0",
         "recharts": "^2.15.1",
+        "rss-parser": "^3.13.0",
         "sonner": "^1.7.2",
         "tailwind-merge": "^2.6.0",
         "zod": "^3.22.4"
@@ -67,7 +69,6 @@
         "autoprefixer": "^10.4.17",
         "chalk": "^5.4.1",
         "date-fns": "^3.6.0",
-        "dotenv": "^16.4.7",
         "eslint": "^8.56.0",
         "eslint-config-next": "14.1.0",
         "eslint-plugin-react": "^7.37.4",
@@ -6799,7 +6800,6 @@
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
       "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -12843,6 +12843,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/rss-parser/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -12928,6 +12947,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -15213,6 +15238,28 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "ai:verify": "node scripts/verify-rule-compliance.js",
     "ai:setup-hooks": "cp .git/hooks/pre-commit.rule-check .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
     "mcp:update-schema": "tsx scripts/update-mcp-schema.ts",
-    "migrations:run": "tsx scripts/run-migrations.ts"
+    "migrations:run": "tsx scripts/run-migrations.ts",
+    "ingest:rss": "ts-node --transpile-only scripts/rss_ingest.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -81,7 +82,9 @@
     "recharts": "^2.15.1",
     "sonner": "^1.7.2",
     "tailwind-merge": "^2.6.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "rss-parser": "^3.13.0",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
@@ -102,7 +105,6 @@
     "autoprefixer": "^10.4.17",
     "chalk": "^5.4.1",
     "date-fns": "^3.6.0",
-    "dotenv": "^16.4.7",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.1.0",
     "eslint-plugin-react": "^7.37.4",

--- a/scripts/rss_ingest.ts
+++ b/scripts/rss_ingest.ts
@@ -1,0 +1,69 @@
+/**
+ * Run with:  npx ts-node --transpile-only scripts/rss_ingest.ts
+ * Requires:  NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (NOT anon)
+ */
+import Parser from 'rss-parser';
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!; // service role bypasses RLS
+const FEEDS = [
+  'https://news.ycombinator.com/rss',
+  'https://feeds.bbci.co.uk/news/technology/rss.xml'
+];
+
+async function main() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Missing SUPABASE env: set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY');
+  }
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
+  const parser = new Parser();
+
+  // create job
+  const { data: job, error: jobErr } = await supabase
+    .from('scraping_jobs')
+    .insert({ source: 'rss', status: 'running' })
+    .select()
+    .single();
+  if (jobErr) throw jobErr;
+
+  for (const feed of FEEDS) {
+    const res = await parser.parseURL(feed);
+    for (const item of res.items) {
+      const url = item.link || '';
+      if (!url) continue;
+
+      const title = item.title || '';
+      const published_at = item.isoDate ? new Date(item.isoDate).toISOString() : null;
+
+      // Upsert on unique URL
+      const { error } = await supabase.from('scraped_items').upsert({
+        job_id: job.id,
+        url,
+        title,
+        published_at,
+        source: 'rss',
+        raw: {
+          feed,
+          title: item.title,
+          contentSnippet: item.contentSnippet
+        }
+      }, { onConflict: 'url' });
+      if (error) console.error('Upsert error:', error.message);
+    }
+  }
+
+  await supabase.from('scraping_jobs')
+    .update({ status: 'finished', finished_at: new Date().toISOString() })
+    .eq('id', job.id);
+
+  console.log('RSS ingest complete');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/supabase/migrations/20250820_01_reviews_extras.sql
+++ b/supabase/migrations/20250820_01_reviews_extras.sql
@@ -1,0 +1,30 @@
+create extension if not exists pgcrypto;
+
+do $$
+begin
+  if not exists (select 1 from pg_type where typname = 'review_status') then
+    create type review_status as enum ('pending','approved','rejected');
+  end if;
+exception when duplicate_object then null;
+end$$;
+
+alter table if exists public.reviews
+  add column if not exists recommend boolean,
+  add column if not exists status review_status not null default 'approved';
+
+create index if not exists idx_reviews_company_id on public.reviews(company_id);
+create index if not exists idx_reviews_rating      on public.reviews(rating);
+
+create or replace view public.company_rating_stats as
+select
+  c.id as company_id,
+  c.name,
+  c.industry,
+  c.location,
+  avg(coalesce(r.rating,0))::numeric(10,4) as avg_rating,
+  count(r.*) as review_count
+from public.companies c
+left join public.reviews r
+  on r.company_id = c.id
+ and (r.status is null or r.status = 'approved')
+group by c.id, c.name, c.industry, c.location;

--- a/supabase/migrations/20250820_02_insights_functions.sql
+++ b/supabase/migrations/20250820_02_insights_functions.sql
@@ -1,0 +1,91 @@
+-- Rising startups
+create or replace function public.get_rising_startup_companies(limit_count int default 20)
+returns table (
+  company_id uuid, name text, industry text, location text,
+  avg_rating numeric, review_count bigint, growth_score numeric
+)
+language sql stable as $$
+  select
+    s.company_id, s.name, s.industry, s.location,
+    s.avg_rating, s.review_count,
+    (s.avg_rating * ln(1 + greatest(s.review_count,1)))::numeric(10,4) as growth_score
+  from public.company_rating_stats s
+  where s.review_count >= 2 and s.avg_rating >= 3.8
+  order by growth_score desc
+  limit limit_count;
+$$;
+
+-- Financial distress
+create or replace function public.get_financial_distress_companies(limit_count int default 20)
+returns table (
+  company_id uuid, name text, industry text, location text,
+  avg_rating numeric, review_count bigint, distress_score numeric
+)
+language sql stable as $$
+  select
+    s.company_id, s.name, s.industry, s.location,
+    s.avg_rating, s.review_count,
+    ((5 - s.avg_rating) * ln(1 + greatest(s.review_count,1)))::numeric(10,4) as distress_score
+  from public.company_rating_stats s
+  where s.review_count >= 2 and s.avg_rating <= 3.2
+  order by distress_score desc
+  limit limit_count;
+$$;
+
+-- Summary stats
+create or replace function public.get_growth_statistics()
+returns table (
+  total_companies bigint, average_score numeric, total_funding numeric,
+  by_industry jsonb, by_indicator_type jsonb, trend_data jsonb
+)
+language plpgsql stable as $$
+begin
+  return query
+  with base as (
+    select count(*)::bigint as total_companies,
+           coalesce(avg((avg_rating * ln(1+review_count))),0)::numeric(10,4) as average_score
+    from public.company_rating_stats
+  ),
+  by_ind as (
+    select industry,
+           coalesce(avg((avg_rating * ln(1+review_count))),0)::numeric(10,4) as score
+    from public.company_rating_stats
+    group by industry
+  )
+  select
+    base.total_companies,
+    base.average_score,
+    0::numeric as total_funding,
+    to_jsonb(array_agg(jsonb_build_object('industry', industry, 'score', score))) filter (where industry is not null),
+    '[]'::jsonb,
+    '[]'::jsonb
+  from base left join by_ind on true;
+end$$;
+
+create or replace function public.get_distress_statistics()
+returns table (
+  total_companies bigint, average_score numeric,
+  by_industry jsonb, by_indicator_type jsonb, trend_data jsonb
+)
+language plpgsql stable as $$
+begin
+  return query
+  with base as (
+    select count(*)::bigint as total_companies,
+           coalesce(avg(((5-avg_rating) * ln(1+review_count))),0)::numeric(10,4) as average_score
+    from public.company_rating_stats
+  ),
+  by_ind as (
+    select industry,
+           coalesce(avg(((5-avg_rating) * ln(1+review_count))),0)::numeric(10,4) as score
+    from public.company_rating_stats
+    group by industry
+  )
+  select
+    base.total_companies,
+    base.average_score,
+    to_jsonb(array_agg(jsonb_build_object('industry', industry, 'score', score))) filter (where industry is not null),
+    '[]'::jsonb,
+    '[]'::jsonb
+  from base left join by_ind on true;
+end$$;

--- a/supabase/migrations/20250820_03_scraping_tables.sql
+++ b/supabase/migrations/20250820_03_scraping_tables.sql
@@ -1,0 +1,48 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.scraping_jobs (
+  id uuid primary key default gen_random_uuid(),
+  source text not null,
+  status text not null default 'queued',
+  meta jsonb default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  started_at timestamptz,
+  finished_at timestamptz
+);
+
+create table if not exists public.scraped_items (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid references public.scraping_jobs(id) on delete set null,
+  company_id uuid references public.companies(id) on delete set null,
+  url text not null,
+  title text,
+  published_at timestamptz,
+  source text,
+  raw jsonb default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- De-dupe by URL for upserts from RSS
+create unique index if not exists uniq_scraped_items_url on public.scraped_items(url);
+
+-- Helpful indexes
+create index if not exists idx_scraped_items_company on public.scraped_items(company_id);
+create index if not exists idx_scraped_items_published on public.scraped_items(published_at);
+
+-- RLS: read for all (writes via service role key)
+alter table public.scraping_jobs enable row level security;
+alter table public.scraped_items enable row level security;
+
+do $$ begin
+  perform 1 from pg_policies where schemaname='public' and tablename='scraping_jobs' and policyname='read_all_jobs';
+  if not found then
+    create policy read_all_jobs on public.scraping_jobs for select using (true);
+  end if;
+end $$;
+
+do $$ begin
+  perform 1 from pg_policies where schemaname='public' and tablename='scraped_items' and policyname='read_all_items';
+  if not found then
+    create policy read_all_items on public.scraped_items for select using (true);
+  end if;
+end $$;

--- a/supabase/seed/seed_minimal.sql
+++ b/supabase/seed/seed_minimal.sql
@@ -1,0 +1,12 @@
+insert into public.companies (name, industry, location)
+values
+  ('Maple Labs', 'Biotech', 'Vancouver, BC'),
+  ('Island Forge', 'Software', 'Colombo, Sri Lanka')
+on conflict do nothing;
+
+with c as (select id from public.companies where name in ('Maple Labs','Island Forge'))
+insert into public.reviews (company_id, rating, recommend, status)
+select id, 5, true, 'approved' from c
+union all
+select id, 4, true, 'approved' from c
+on conflict do nothing;


### PR DESCRIPTION
## Summary
- add review recommendation/status columns and company rating stats view
- add insight RPCs for growth and distress statistics
- add scraping job/item tables with RLS and unique URL index
- seed minimal companies and reviews for demo data
- add RSS ingestion script and dependencies

## Testing
- `npm test` *(fails: Failed to resolve import "node-mocks-http"; 22 failed tests)*


------
https://chatgpt.com/codex/tasks/task_b_68a68a5b980c83339d6470316a763b33